### PR TITLE
Issue #1 - remove the implicit cast to IdentifierNameSyntax

### DIFF
--- a/src/TestUpdaterAnalyzers.Test/ArgumentsFixTests.cs
+++ b/src/TestUpdaterAnalyzers.Test/ArgumentsFixTests.cs
@@ -162,6 +162,57 @@ namespace RhinoXUnitFixture
         }
 
         [TestMethod]
+        public void ArgumentEqualExpression()
+        {
+            var test = @"
+using Rhino.Mocks;
+using Xunit;
+using SampleBusinessLogic;
+
+namespace RhinoXUnitFixture
+{
+    public class RhinoMocksTests
+    {
+        [Fact]
+        public void WhenValid_IdCalculated()
+        {
+            var mock = MockRepository.GenerateMock<IValidator>();
+            mock.Expect(x => x.Validate(Arg<Request>.Is.Equal(new Request() { Age = 1, Height = 1, Name = ""test"" }))).Return(true);
+            var sut = new BusinessLogic(mock);
+            var result = sut.CalculateId(request);
+            Assert.Equal(5, result);
+        }
+    }
+}
+";
+
+
+            var expectedSource = @"
+using NSubstitute;
+using Rhino.Mocks;
+using Xunit;
+using SampleBusinessLogic;
+
+namespace RhinoXUnitFixture
+{
+    public class RhinoMocksTests
+    {
+        [Fact]
+        public void WhenValid_IdCalculated()
+        {
+            var mock = Substitute.For<IValidator>();
+            mock.Validate(NSubstitute.Arg.Is<Request>(a0 => a0 == new Request() { Age = 1, Height = 1, Name = ""test"" })).Returns(true);
+            var sut = new BusinessLogic(mock);
+            var result = sut.CalculateId(request);
+            Assert.Equal(5, result);
+        }
+    }
+}
+";
+            VerifyCSharpFix(test, expectedSource, allowNewCompilerDiagnostics: false);
+        }
+
+        [TestMethod]
         public void ArgumentSame()
         {
             var test = @"
@@ -215,6 +266,57 @@ namespace RhinoXUnitFixture
         }
 
         [TestMethod]
+        public void ArgumentSameExpression()
+        {
+            var test = @"
+using Rhino.Mocks;
+using Xunit;
+using SampleBusinessLogic;
+
+namespace RhinoXUnitFixture
+{
+    public class RhinoMocksTests
+    {
+        [Fact]
+        public void WhenValid_IdCalculated()
+        {
+            var mock = MockRepository.GenerateMock<IValidator>();
+            mock.Expect(x => x.Validate(Arg<Request>.Is.Same(new Request() { Age = 1, Height = 1, Name = ""test"" }))).Return(true);
+            var sut = new BusinessLogic(mock);
+            var result = sut.CalculateId(request);
+            Assert.Equal(5, result);
+        }
+    }
+}
+";
+
+
+            var expectedSource = @"
+using NSubstitute;
+using Rhino.Mocks;
+using Xunit;
+using SampleBusinessLogic;
+
+namespace RhinoXUnitFixture
+{
+    public class RhinoMocksTests
+    {
+        [Fact]
+        public void WhenValid_IdCalculated()
+        {
+            var mock = Substitute.For<IValidator>();
+            mock.Validate(NSubstitute.Arg.Is<Request>(a0 => ReferenceEquals(a0, new Request() { Age = 1, Height = 1, Name = ""test"" }))).Returns(true);
+            var sut = new BusinessLogic(mock);
+            var result = sut.CalculateId(request);
+            Assert.Equal(5, result);
+        }
+    }
+}
+";
+            VerifyCSharpFix(test, expectedSource, allowNewCompilerDiagnostics: false);
+        }
+
+        [TestMethod]
         public void ArgumentMatches()
         {
             var test = @"
@@ -255,6 +357,57 @@ namespace RhinoXUnitFixture
         {
             var mock = Substitute.For<IValidator>();
             mock.Validate(NSubstitute.Arg.Is<Request>(y => y.Name == ""test"")).Returns(true);
+            var sut = new BusinessLogic(mock);
+            var result = sut.CalculateId(new Request() { Age = 1, Height = 1, Name = ""test"" });
+            Assert.Equal(5, result);
+        }
+    }
+}
+";
+            VerifyCSharpFix(test, expectedSource, allowNewCompilerDiagnostics: false);
+        }
+
+        [TestMethod]
+        public void ArgumentMatchesExpression()
+        {
+            var test = @"
+using Rhino.Mocks;
+using Xunit;
+using SampleBusinessLogic;
+
+namespace RhinoXUnitFixture
+{
+    public class RhinoMocksTests
+    {
+        [Fact]
+        public void WhenValid_IdCalculated()
+        {
+            var mock = MockRepository.GenerateMock<IValidator>();
+            mock.Expect(x => x.Validate(Arg<Request>.Matches(y => y.Name == ""test"".ToLower()))).Return(true);
+            var sut = new BusinessLogic(mock);
+            var result = sut.CalculateId(new Request() { Age = 1, Height = 1, Name = ""test"" });
+            Assert.Equal(5, result);
+        }
+    }
+}
+";
+
+
+            var expectedSource = @"
+using NSubstitute;
+using Rhino.Mocks;
+using Xunit;
+using SampleBusinessLogic;
+
+namespace RhinoXUnitFixture
+{
+    public class RhinoMocksTests
+    {
+        [Fact]
+        public void WhenValid_IdCalculated()
+        {
+            var mock = Substitute.For<IValidator>();
+            mock.Validate(NSubstitute.Arg.Is<Request>(y => y.Name == ""test"".ToLower())).Returns(true);
             var sut = new BusinessLogic(mock);
             var result = sut.CalculateId(new Request() { Age = 1, Height = 1, Name = ""test"" });
             Assert.Equal(5, result);

--- a/src/TestUpdaterAnalyzers/RhinoSyntaxRewriter.cs
+++ b/src/TestUpdaterAnalyzers/RhinoSyntaxRewriter.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -193,17 +192,17 @@ namespace TestUpdaterAnalyzers
                 {
                     if (RhinoRecognizer.IsEqualArgMethod(methodSymbol))
                     {
-                        var equalsTo = argumentMethodInvocation.ArgumentList.Arguments.First().Expression as IdentifierNameSyntax;
+                        var equalsTo = argumentMethodInvocation.ArgumentList.Arguments.First().Expression;
                         return UseArgWith(node, GetEqualsToGivenArgument(_methodContext.Current.UnusedLambdaToken, equalsTo));
                     }
                     if (RhinoRecognizer.IsSameArgMethod(methodSymbol))
                     {
-                        var sameTo = argumentMethodInvocation.ArgumentList.Arguments.First().Expression as IdentifierNameSyntax;
+                        var sameTo = argumentMethodInvocation.ArgumentList.Arguments.First().Expression;
                         return UseArgWith(node, GetReferenceEqualsToGivenArgument(_methodContext.Current.UnusedLambdaToken, sameTo));
                     }
                     if (RhinoRecognizer.IsMatchesArgMethod(methodSymbol))
                     {
-                        var lambdaArgument = argumentMethodInvocation.ArgumentList.Arguments.First().Expression as SimpleLambdaExpressionSyntax;
+                        var lambdaArgument = argumentMethodInvocation.ArgumentList.Arguments.First().Expression;
                         return UseArgWith(node, GetLambdaAsArgument(_methodContext.Current.UnusedLambdaToken, lambdaArgument));
                     }
                 }
@@ -500,7 +499,7 @@ namespace TestUpdaterAnalyzers
                     SyntaxFactory.BinaryExpression(SyntaxKind.NotEqualsExpression, SyntaxFactory.IdentifierName(token), SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression))))));
         }
 
-        private ArgumentListSyntax GetEqualsToGivenArgument(SyntaxToken token, IdentifierNameSyntax equalsTo)
+        private ArgumentListSyntax GetEqualsToGivenArgument(SyntaxToken token, ExpressionSyntax equalsTo)
         {
             return SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList(
                 SyntaxFactory.Argument(
@@ -508,7 +507,7 @@ namespace TestUpdaterAnalyzers
                     SyntaxFactory.BinaryExpression(SyntaxKind.EqualsExpression, SyntaxFactory.IdentifierName(token), equalsTo)))));
         }
 
-        private ArgumentListSyntax GetReferenceEqualsToGivenArgument(SyntaxToken token, IdentifierNameSyntax sameAs)
+        private ArgumentListSyntax GetReferenceEqualsToGivenArgument(SyntaxToken token, ExpressionSyntax sameAs)
         {
             return SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList(
                 SyntaxFactory.Argument(
@@ -518,7 +517,7 @@ namespace TestUpdaterAnalyzers
             )))));
         }
 
-        private ArgumentListSyntax GetLambdaAsArgument(SyntaxToken token, SimpleLambdaExpressionSyntax lambdaArgument)
+        private ArgumentListSyntax GetLambdaAsArgument(SyntaxToken token, ExpressionSyntax lambdaArgument)
         {
             return SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList(
                 SyntaxFactory.Argument(lambdaArgument)));


### PR DESCRIPTION
Expressions in the Arg<T>.Is.Equal and Arg<T>.Is.Same parameters were causing the analyzer to crash in Visual Studio.

Added new tests around the Equal, Same, and Matches that takes expressions as parameters.
